### PR TITLE
Pin to hdf5 1.8.17*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,38 +1,14 @@
 #!/usr/bin/env bash
 
-if [ "$(uname)" == "Darwin" ]
-then
-    # for Mac OSX
-    export CC=clang
-    export CXX=clang++
-    export MACOSX_VERSION_MIN="10.7"
-    export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
-    export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
-    export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export LDFLAGS="${LDFLAGS} -stdlib=libc++ -lc++"
-    export LINKFLAGS="${LDFLAGS}"
-elif [ "$(uname)" == "Linux" ]
-then
-    # for Linux
-    export CC=gcc
-    export CXX=g++
-    export CXXFLAGS="${CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
-    export LDFLAGS="${LDFLAGS}"
-    export LINKFLAGS="${LDFLAGS}"
-else
-    echo "This system is unsupported by the toolchain."
-    exit 1
+if [ $(uname) == Darwin ]; then
+  export CXX="${CXX} -stdlib=libc++"
 fi
 
-export CFLAGS="${CFLAGS} -m${ARCH}"
-export CXXFLAGS="${CXXFLAGS} -m${ARCH}"
 
+mkdir build_libradolan && cd build_libradolan
+cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D WITH_TESTS=YES \
+      $SRC_DIR
 
-mkdir ../build
-cd ../build
-cmake $SRC_DIR \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DWITH_TESTS=YES
 make VERBOSE=1
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d435f21b6f74ba42669e390d43a3b6ab401ec3a9420e7fb13d7971a7a71c3c0e
 
 build:
-  number: 1
+  number: 2
   skip: true   # [win]
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - cmake
   run:
     - boost 1.60.*
-    - hdf5 1.8.15*
+    - hdf5 1.8.17*
     - netcdf-cxx4
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,13 +16,12 @@ build:
 
 requirements:
   build:
-    - boost 1.60.*
-    - netcdf-cxx4
     - cmake
+    - boost 1.61.*
+    - netcdf-cxx4 4.3.*
   run:
-    - boost 1.60.*
-    - hdf5 1.8.17*
-    - netcdf-cxx4
+    - boost 1.61.*
+    - netcdf-cxx4 4.3.*
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,10 @@ build:
 requirements:
   build:
     - cmake
-    - boost 1.61.*
+    - boost 1.60.*
     - netcdf-cxx4 4.3.*
   run:
-    - boost 1.61.*
+    - boost 1.60.*
     - netcdf-cxx4 4.3.*
 
 test:
@@ -34,7 +34,7 @@ test:
 about:
   home: http://meteo-ubonn.github.io/radolan/
   license: MIT
-  summary:  C++ library for reading and working with the RADOLAN data format of the German Weather Service (DWD)
+  summary: C++ library for reading and working with the RADOLAN data format of the German Weather Service (DWD)
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - cmake
     - boost 1.60.*
     - netcdf-cxx4 4.3.*
+    - toolchain
   run:
     - boost 1.60.*
     - netcdf-cxx4 4.3.*


### PR DESCRIPTION
@kmuehlbauer I am pinning against the latest hdf5 available in conda-forge. This will be used in all packages soon. Please take a look at it and merge if you think it is OK.

Needs: https://github.com/conda-forge/netcdf-cxx4-feedstock/pull/7 and https://github.com/conda-forge/libnetcdf-feedstock/pull/1
